### PR TITLE
add single-anchor option

### DIFF
--- a/bin/from_camera.py
+++ b/bin/from_camera.py
@@ -9,8 +9,14 @@ from model.yolov3 import LABELS, ANCHORS
 if __name__ == '__main__':
     # load yolov3 model
     no_nms = "--no-nms" in sys.argv
+    single_anchor = "--single-anchor" in sys.argv
     if no_nms:
         print("WARNING: Non-max suppression is disabled.\n")
+
+
+    if single_anchor:
+        print("WARNING: Using single anchor.\n")
+
     model = load_model('modelweights/model.h5')
     # define the expected input shape for the model
     input_w, input_h = 416, 416
@@ -29,6 +35,8 @@ if __name__ == '__main__':
         image = image.reshape(1, input_w, input_h, 3)
 
         yhat = model.predict(image / 255.)
+        # import pdb; pdb.set_trace()
+        # print(yhat)
 
         class_threshold = 0.6
         boxes = list()
@@ -36,6 +44,8 @@ if __name__ == '__main__':
             # decode the output of the network
             boxes += decode_netout(yhat[i][0], ANCHORS[i],
                                    class_threshold, input_h, input_w)
+            if single_anchor:
+                break
         correct_yolo_boxes(boxes, image_h, image_w, input_h, input_w)
         # import pdb; pdb.set_trace()
         if not no_nms:

--- a/bin/from_camera.py
+++ b/bin/from_camera.py
@@ -15,7 +15,7 @@ if __name__ == '__main__':
 
 
     if single_anchor:
-        print("WARNING: Using single anchor.\n")
+        print("WARNING: Using single anchor. This will impact detection performance.\n")
 
     model = load_model('modelweights/model.h5')
     # define the expected input shape for the model

--- a/model/utils.py
+++ b/model/utils.py
@@ -7,6 +7,16 @@ from keras.preprocessing.image import img_to_array
 from matplotlib import pyplot
 from matplotlib.patches import Rectangle
 import cv2
+import time
+
+def timit(func):
+    def wrapper(*args, **kwargs):
+        then = time.time()
+        res = func(*args, **kwargs)
+        now = time.time()
+        print(func.__name__, 'executed in', round(now - then, 2), 'seconds.')
+        return res
+    return wrapper
 
 
 class WeightReader:
@@ -91,7 +101,7 @@ class BoundBox:
 def _sigmoid(x):
     return 1. / (1. + np.exp(-x))
 
-
+# @timit
 def decode_netout(netout, anchors, obj_thresh, net_h, net_w):
     grid_h, grid_w = netout.shape[:2]
     nb_box = 3
@@ -125,6 +135,7 @@ def decode_netout(netout, anchors, obj_thresh, net_h, net_w):
     return boxes
 
 
+# @timit
 def correct_yolo_boxes(boxes, image_h, image_w, net_h, net_w):
     new_w, new_h = net_w, net_h
     for i in range(len(boxes)):


### PR DESCRIPTION
add --single-anchor argument to restrict detection using single anchor box.
i.e. `.\main.bat --no-nms --single-anchor`

the third anchor seems to be the main bottleneck in current implementation. single anchor option will run on only the first anchor